### PR TITLE
Update to Box version 3.7.0@96d1abc 2019-04-09 20:35:35 UTC

### DIFF
--- a/Formula/box.rb
+++ b/Formula/box.rb
@@ -1,19 +1,19 @@
 class Box < Formula
-  desc "📦🚀 Fast, zero config application bundler with PHARs."
+  desc "📦🚀 Fast, zero config application bundler with PHARs"
   homepage "https://github.com/humbug/box"
   url "https://github.com/humbug/box/releases/download/3.0.0/box.phar"
-  sha256 "397f012cae0e7124cc2f949daa45cef594bfe2784c700fe33724dea43ce89777"
   version "3.0.0"
+  sha256 "397f012cae0e7124cc2f949daa45cef594bfe2784c700fe33724dea43ce89777"
 
   bottle :unneeded
 
   depends_on "php" if MacOS.version <= :el_capitan
 
   def install
-      bin.install "box.phar" => "box"
+    bin.install "box.phar" => "box"
   end
 
   test do
-      shell_output("#{bin}/box --version").include?(version)
+    shell_output("#{bin}/box --version").include?(version)
   end
 end

--- a/Formula/box.rb
+++ b/Formula/box.rb
@@ -1,8 +1,8 @@
 class Box < Formula
   desc "📦🚀 Fast, zero config application bundler with PHARs"
   homepage "https://github.com/humbug/box"
-  url "https://github.com/humbug/box/releases/download/3.0.0/box.phar"
-  sha256 "397f012cae0e7124cc2f949daa45cef594bfe2784c700fe33724dea43ce89777"
+  url "https://github.com/humbug/box/releases/download/3.7.0/box.phar"
+  sha256 "57daab20d12c9eeec2cf244b0f1966327de369a66d2f59ed3bda6a3f5e9f05a9"
 
   bottle :unneeded
 

--- a/Formula/box.rb
+++ b/Formula/box.rb
@@ -2,7 +2,6 @@ class Box < Formula
   desc "📦🚀 Fast, zero config application bundler with PHARs"
   homepage "https://github.com/humbug/box"
   url "https://github.com/humbug/box/releases/download/3.0.0/box.phar"
-  version "3.0.0"
   sha256 "397f012cae0e7124cc2f949daa45cef594bfe2784c700fe33724dea43ce89777"
 
   bottle :unneeded


### PR DESCRIPTION
Also fixed the Homebrew lint error below:
- Fix: https://github.com/KEINOS/homebrew-box/issues/1 `Formula style test fails in "brew audit --new-formula" command`
- Related issue: https://github.com/KEINOS/homebrew-box/issues/2 `Update formula to BOX v3.7.0 from v3.0.0`

Tested work in the forked repo below:
- https://github.com/KEINOS/homebrew-box