### PR TITLE
feat: remove deprecated `bottle :unneeded`

### DIFF
--- a/Formula/box.rb
+++ b/Formula/box.rb
@@ -4,8 +4,6 @@ class Box < Formula
   url "https://github.com/box-project/box/releases/download/3.13.0/box.phar"
   sha256 "b438b65fee5d633ee7d322086bebcea0910079e53c1f2dccb6f449f9fd3fa2e2"
 
-  bottle :unneeded
-
   depends_on "php" if MacOS.version <= :el_capitan
 
   def install


### PR DESCRIPTION
This has recently become deprecated and now throws a warning when installing via Brew.

```txt
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the humbug/box tap (not Homebrew/brew or Homebrew/core):
  /usr/local/Homebrew/Library/Taps/humbug/homebrew-box/Formula/box.rb:7
```

Fixes #8