### PR TITLE
Update box to 3.14.0

### DIFF
--- a/Formula/box.rb
+++ b/Formula/box.rb
@@ -1,8 +1,8 @@
 class Box < Formula
   desc "📦🚀 Fast, zero config application bundler with PHARs"
   homepage "https://github.com/box-project/box"
-  url "https://github.com/box-project/box/releases/download/3.13.0/box.phar"
-  sha256 "b438b65fee5d633ee7d322086bebcea0910079e53c1f2dccb6f449f9fd3fa2e2"
+  url "https://github.com/box-project/box/releases/download/3.14.0/box.phar"
+  sha256 "dbbd211f7690845a5e545105b569be7b7b2c671c2b2e0dfab571c708562e7bf4"
 
   depends_on "php" if MacOS.version <= :el_capitan
 


### PR DESCRIPTION
There is no box.phar release for 3.14.1 and so I am only upgrading to 3.14.0.